### PR TITLE
Add `actions: read` permission to `actionci` job

### DIFF
--- a/.github/workflows/actionci.yml
+++ b/.github/workflows/actionci.yml
@@ -17,5 +17,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     uses: smallstep/workflows/.github/workflows/actionci.yml@main
     secrets: inherit


### PR DESCRIPTION
The `actionci` job was failing with the following error:

`The workflow is not valid. .github/workflows/actionci.yml (Line: 16, Col: 3): Error calling workflow 'smallstep/workflows/.github/workflows/actionci.yml@main'. The nested job 'zizmor' is requesting 'actions: read', but is only allowed 'actions: none'.`